### PR TITLE
Add error handling to run.bat

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,5 +1,12 @@
 @echo off
-python -m venv venv
-call venv\Scripts\activate
-pip install -r requirements.txt
-python main.py
+
+python -m venv venv || goto :error
+call venv\Scripts\activate || goto :error
+pip install -r requirements.txt || goto :error
+python main.py || goto :error
+
+exit /b 0
+
+:error
+echo launch terminal > error.log
+exit /b 1


### PR DESCRIPTION
## Summary
- enhance `run.bat` with error handling
- write `launch terminal` to `error.log` when a step fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config_agent', etc.)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement opencv-python)*

------
https://chatgpt.com/codex/tasks/task_b_686964d19af0832696c9805fd05d9e94