### PR TITLE
Run unittests

### DIFF
--- a/config_agent.py
+++ b/config_agent.py
@@ -8,7 +8,7 @@ class ConfigAgent:
     DEFAULTS = {
         "output_path": "output.mp4",
         "frame_rate": 24,
-        "video_codec": "mp4v",
+        "video_codec": "libx264",
     }
 
     def __init__(self, config_path: str | None = None, overrides: dict | None = None):

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ def main():
         overrides={
             "output_path": "sample_output.mp4",
             "frame_rate": 24,
-            "video_codec": "mp4v",
+            "video_codec": "libx264",
         }
     )
     gui = GUIController(cfg)

--- a/tests/test_config_agent.py
+++ b/tests/test_config_agent.py
@@ -11,7 +11,7 @@ class TestConfigAgent(unittest.TestCase):
         cfg = ConfigAgent()
         self.assertEqual(cfg.get_output_path(), "output.mp4")
         self.assertEqual(cfg.get_frame_rate(), 24)
-        self.assertEqual(cfg.get_video_codec(), "mp4v")
+        self.assertEqual(cfg.get_video_codec(), "libx264")
 
     def test_config_file_override(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/video_stitcher.py
+++ b/video_stitcher.py
@@ -7,7 +7,7 @@ import moviepy.editor as mpy
 class VideoStitcher:
     """Stitch interpolated clips into a final video."""
 
-    def __init__(self, codec: str = "mp4v"):
+    def __init__(self, codec: str = "libx264"):
         self.codec = codec
 
     def stitch(self, clips: List[List], output_path: str, frame_rate: int) -> str:


### PR DESCRIPTION
## Summary
- default to libx264 codec for video encoding
- adjust tests to expect libx264

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_b_686966cba8f48326943b1a9219d1df7a