### PR TITLE
Enforce 1024x1024 PNG keyframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ Preview the 5-second video.
 Save to a custom path (default: sample_output.mp4).
 
 Sample Keyframes
-Put three PNG/JPG images (start, midpoint, end of a movement) into sample_images/. The app expects exactly three files.
+Provide exactly three PNG images sized 1024x1024 pixels (start, midpoint and end frames) in the `sample_images/` folder. The loader rejects images that are not PNG or not 1024x1024.
 
 Output
 Default: sample_output.mp4
 
-~5 seconds at 24 fps (configurable via --frame_rate or GUI settings)
+~5 seconds at 24 fps (configurable via --frame_rate or GUI settings).
+The output video always has a 1:1 aspect ratio.
 
 Codec and output path can be changed in config.ini or via CLI flags.
 

--- a/frame_loader.py
+++ b/frame_loader.py
@@ -1,3 +1,4 @@
+import os
 import cv2
 
 class FrameLoader:
@@ -10,9 +11,20 @@ class FrameLoader:
 
         frames = []
         for path in paths:
+            ext = os.path.splitext(path)[1].lower()
+            if ext != ".png":
+                raise ValueError(f"Keyframe must be a PNG file: {path}")
+
             img = cv2.imread(path)
             if img is None:
                 raise FileNotFoundError(f"Failed to load image: {path}")
+
+            h, w = img.shape[:2]
+            if h != 1024 or w != 1024:
+                raise ValueError(
+                    f"Keyframe must be 1024x1024 pixels: {path} is {w}x{h}"
+                )
+
             frames.append(img)
 
         return frames

--- a/tests/test_frame_loader.py
+++ b/tests/test_frame_loader.py
@@ -9,8 +9,8 @@ from frame_loader import FrameLoader
 
 
 class TestFrameLoader(unittest.TestCase):
-    def create_dummy_image(self, path):
-        img = np.zeros((10, 10, 3), dtype=np.uint8)
+    def create_dummy_image(self, path, size=(1024, 1024)):
+        img = np.zeros((size[0], size[1], 3), dtype=np.uint8)
         cv2.imwrite(path, img)
 
     def test_load_frames_three_images(self):
@@ -24,7 +24,21 @@ class TestFrameLoader(unittest.TestCase):
             frames = FrameLoader.load_frames(paths)
             self.assertEqual(len(frames), 3)
             for f in frames:
-                self.assertEqual(f.shape, (10, 10, 3))
+                self.assertEqual(f.shape[:2], (1024, 1024))
+
+    def test_invalid_extension_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = os.path.join(tmpdir, "img.jpg")
+            self.create_dummy_image(p)
+            with self.assertRaises(ValueError):
+                FrameLoader.load_frames([p, p, p])
+
+    def test_invalid_size_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = os.path.join(tmpdir, "img.png")
+            self.create_dummy_image(p, size=(512, 512))
+            with self.assertRaises(ValueError):
+                FrameLoader.load_frames([p, p, p])
 
 
 if __name__ == "__main__":

--- a/tests/test_video_stitcher.py
+++ b/tests/test_video_stitcher.py
@@ -30,6 +30,16 @@ class TestVideoStitcher(unittest.TestCase):
             stitcher.stitch(clips, out, frame_rate=2)
             self.assertTrue(os.path.exists(out))
 
+    def test_non_square_frames_raise(self):
+        if not MOVIEPY_AVAILABLE:
+            self.skipTest("moviepy not available")
+        bad_clip = [np.zeros((8, 4, 3), dtype=np.uint8) for _ in range(2)]
+        stitcher = VideoStitcher()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, "out.mp4")
+            with self.assertRaises(ValueError):
+                stitcher.stitch([bad_clip], out, frame_rate=2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/video_stitcher.py
+++ b/video_stitcher.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List
 
-import moviepy.editor as mpy
+from moviepy import ImageSequenceClip, concatenate_videoclips
 
 
 class VideoStitcher:
@@ -35,14 +35,21 @@ class VideoStitcher:
         for idx, frames in enumerate(clips):
             if not frames:
                 continue
-            logging.info("Creating subclip %d with %d frames", idx + 1, len(frames))
-            subclip = mpy.ImageSequenceClip(frames, fps=frame_rate)
+            h, w = frames[0].shape[:2]
+            if h != w:
+                raise ValueError(
+                    f"Clip {idx + 1} is not square: {w}x{h}. Aspect ratio must be 1:1"
+                )
+            logging.info(
+                "Creating subclip %d with %d frames", idx + 1, len(frames)
+            )
+            subclip = ImageSequenceClip(frames, fps=frame_rate)
             video_clips.append(subclip)
 
         if not video_clips:
             raise ValueError("All provided clips were empty")
 
-        final = mpy.concatenate_videoclips(video_clips)
+        final = concatenate_videoclips(video_clips)
         logging.info("Writing output video to %s", output_path)
         final.write_videofile(output_path, codec=self.codec, fps=frame_rate, audio=False)
         logging.info("Video written successfully")


### PR DESCRIPTION
## Summary
- validate that all keyframes are PNGs sized 1024x1024
- ensure stitched clips are square before writing video
- update README with new requirements
- expand frame loader and video stitcher tests

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_b_6869686ccf9c83268fa6d00a1cade4c5