### PR TITLE
Update tests section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ Minimal Tkinter interface for file selection and preview.
 ConfigAgent
 Parse and apply output path, frame rate and codec settings.
 
-Tests
-Unit tests cover FrameLoader and VideoStitcher. Run:
 
-bash
-Copy
-Edit
+## Tests
+
+Run the unit tests with:
+
+```bash
 python -m unittest discover -s tests -v
-Tests require OpenCV, NumPy and MoviePy.
+```
+
+The tests require OpenCV, NumPy and MoviePy.
 
 Keep it simple. No fluff.


### PR DESCRIPTION
## Summary
- clarify how to run the tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_b_686969bfb5248326b10644643e120444