### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ bash
 Copy
 Edit
 pip install -r requirements.txt
+git clone https://github.com/Wan-Video/Wan2.1.git
+pip install -r Wan2.1\requirements.txt
+pip install -e Wan2.1
 Alternatively, run the bundled script:
 
 bat
@@ -34,6 +37,8 @@ Copy
 Edit
 run.bat
 That creates the venv, installs requirements and launches the GUI.
+It also clones the Wan2.1 repository and installs its requirements so the local
+`wan` module is available.
 If any command fails the batch script will now pause so you can
 read the error message before the window closes.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 opencv-python
 moviepy
 numpy
-wan

--- a/run.bat
+++ b/run.bat
@@ -2,6 +2,9 @@
 
 python -m venv venv || goto :error
 call venv\Scripts\activate || goto :error
+if not exist Wan2.1 (git clone https://github.com/Wan-Video/Wan2.1.git) || goto :error
+pip install -r Wan2.1\requirements.txt || goto :error
+pip install -e Wan2.1 || goto :error
 pip install -r requirements.txt || goto :error
 python main.py || goto :error
 

--- a/video_stitcher.py
+++ b/video_stitcher.py
@@ -3,8 +3,12 @@ from typing import List
 
 try:
     import moviepy.editor as mpy  # MoviePy <2.2.0
+    ImageSequenceClip = mpy.ImageSequenceClip
+    concatenate_videoclips = mpy.concatenate_videoclips
 except Exception:  # pragma: no cover - fallback for newer MoviePy versions
     import moviepy as mpy
+    ImageSequenceClip = mpy.ImageSequenceClip
+    concatenate_videoclips = mpy.concatenate_videoclips
 
 class VideoStitcher:
     """Stitch interpolated clips into a final video."""


### PR DESCRIPTION
## Summary
- clarify Wan2.1 manual setup steps in README
- drop the non-existent `wan` package from requirements

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68696a46b6848326a9b63e96aacbf031