### PR TITLE
Update docs for fail fast behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,7 @@ Responsibility: Parse and apply configuration options:
 - **output_path**: Path to save the generated video file.
 - **frame_rate**: Frames per second for the output video.
 - **video_codec**: Codec used for encoding the video (e.g., `mp4v`).
+
+## Fail Fast
+All modules should raise clear exceptions on error conditions. Do not
+silently continue when something goes wrong.

--- a/README.md
+++ b/README.md
@@ -103,5 +103,6 @@ python -m unittest discover -s tests -v
 ```
 
 The tests require OpenCV, NumPy and MoviePy.
+The code fails fast: errors raise exceptions rather than being ignored.
 
 Keep it simple. No fluff.


### PR DESCRIPTION
## Summary
- clarify fail-fast policy in `AGENTS.md`
- document fail-fast behavior in `README.md`

## Testing
- `pip install numpy opencv-python-headless moviepy pytest`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68696d6c5c608326b8c644def84c4c67