### PR TITLE
Ignore local Wan2.1 clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ error.log
 # IDE files
 .vscode/
 .idea/
+
+# Wan2.1 model
+Wan2.1/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ pip install -r requirements.txt
 git clone https://github.com/Wan-Video/Wan2.1.git
 pip install -r Wan2.1\requirements.txt
 pip install -e Wan2.1
+# The Wan2.1 directory is git-ignored so cloned files won't be committed
 Alternatively, run the bundled script:
 
 bat


### PR DESCRIPTION
## Summary
- ensure the Wan2.1 model directory is ignored by git
- document that in README

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_b_68696e3bb21083269f4f16e99fbdc4f7