### PR TITLE
Fix batch install order

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,25 @@ python -m venv venv
 venv\Scripts\activate
 Install dependencies:
 
-bash
-Copy
-Edit
+```
 pip install -r requirements.txt
 git clone https://github.com/Wan-Video/Wan2.1.git
-pip install -r Wan2.1\requirements.txt
+# Install PyTorch first (replace cu118 with your CUDA version)
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+# Install Wan2.1 requirements after PyTorch so flash-attn can build
+pip install --find-links deps --no-build-isolation -r Wan2.1\requirements.txt
 pip install -e Wan2.1
+```
 # The Wan2.1 directory is git-ignored so cloned files won't be committed
 Alternatively, run the bundled script:
 
-bat
-Copy
-Edit
+```
 run.bat
-That creates the venv, installs requirements and launches the GUI.
-It also clones the Wan2.1 repository and installs its requirements so the local
-`wan` module is available.
+```
+That creates the venv, installs requirements (including PyTorch and flash-attn)
+and launches the GUI. It also clones the Wan2.1 repository so the local `wan`
+module is available. The script checks the `deps` folder for PyTorch or
+flash-attn wheels using `--find-links` before downloading from PyPI.
 If any command fails the batch script will now pause so you can
 read the error message before the window closes.
 

--- a/run.bat
+++ b/run.bat
@@ -2,10 +2,23 @@
 
 python -m venv venv || goto :error
 call venv\Scripts\activate || goto :error
+
+:: Clone Wan2.1 if it isn't already present
 if not exist Wan2.1 (git clone https://github.com/Wan-Video/Wan2.1.git) || goto :error
-pip install -r Wan2.1\requirements.txt || goto :error
+
+:: ---- PyTorch and flash-attn ----
+:: Install PyTorch from local wheels if available, otherwise use the official index
+if exist deps\torch*.whl (
+    pip install deps\torch*.whl deps\torchvision*.whl deps\torchaudio*.whl || goto :error
+) else (
+    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118 || goto :error
+)
+
+:: Install Wan2.1 and project requirements after PyTorch so flash-attn can build
+pip install --find-links deps --no-build-isolation -r Wan2.1\requirements.txt || goto :error
 pip install -e Wan2.1 || goto :error
 pip install -r requirements.txt || goto :error
+
 python main.py || goto :error
 
 exit /b 0


### PR DESCRIPTION
## Summary
- reorder run.bat to install PyTorch before Wan2.1 requirements
- install Wan2.1 dependencies with `--find-links` for offline wheels
- update README install instructions to match batch script

## Testing
- `pip install numpy opencv-python moviepy`
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_b_68696f77143c8326b4a7a09fbb655772