### PR TITLE
Remove outdated CLI doc reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ Generate a 5-second demo video from three key-frame images using the Wan 2.1 FLF
 
 ## Usage
 
-### Command-Line
-```bash
-python main.py --frames frame1.png frame2.png frame3.png
-```
-
 ### GUI
 ```bash
 python main.py


### PR DESCRIPTION
## Summary
- remove README CLI instructions for `--frames`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6869dc5b565883269432c3e97a15a8a2