### PR TITLE
Restrict GUI to PNG input

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ Generate a 5-second demo video from three key-frame images using the Wan 2.1 FLF
 
 ## Usage
 
-### Command-Line
-```bash
-python main.py --frames frame1.png frame2.png frame3.png
-```
 
 ### GUI
 ```bash
@@ -47,7 +43,7 @@ python main.py
 ```
 In the Tkinter window:
 
-- Select exactly three key-frame images.
+- Select exactly three key-frame PNG images.
 - Click **Generate**.
 - Preview the 5-second video.
 - Save to a custom path (default: `sample_output.mp4`).
@@ -58,16 +54,16 @@ Provide exactly three PNG images sized 1024x1024 pixels (start, midpoint and end
 Output
 Default: sample_output.mp4
 
-~5 seconds at 24 fps (configurable via --frame_rate or GUI settings).
+~5 seconds at 24 fps (configurable via config.ini or GUI).
 The output video always has a 1:1 aspect ratio.
 
-Codec and output path can be changed in config.ini or via CLI flags.
+Codec and output path can be changed in config.ini or via the GUI.
 
-Configuration
-Option	CLI flag	Default
-Output path	--output_path PATH	sample_output.mp4
-Frame rate	--frame_rate FPS	24
-Video codec	--video_codec CODEC	libx264
+## Configuration
+Option       Default
+Output path  sample_output.mp4
+Frame rate   24
+Video codec  libx264
 
 Components
 FrameLoader

--- a/config_agent.py
+++ b/config_agent.py
@@ -6,7 +6,7 @@ class ConfigAgent:
     """Parse configuration options for the FLF2V workflow."""
 
     DEFAULTS = {
-        "output_path": "output.mp4",
+        "output_path": "sample_output.mp4",
         "frame_rate": 24,
         "video_codec": "libx264",
     }

--- a/gui_controller.py
+++ b/gui_controller.py
@@ -31,7 +31,10 @@ class GUIController:
         tk.Label(self.root, textvariable=self.status_var).pack(pady=5)
 
     def select_files(self):
-        paths = filedialog.askopenfilenames(title="Select exactly 3 keyframes", filetypes=[("Image files", "*.png;*.jpg;*.jpeg;*.bmp")])
+        paths = filedialog.askopenfilenames(
+            title="Select exactly 3 keyframes",
+            filetypes=[("PNG images", "*.png")],
+        )
         if len(paths) != 3:
             messagebox.showerror("Error", "Please select exactly three images")
             return

--- a/main.py
+++ b/main.py
@@ -6,13 +6,7 @@ from gui_controller import GUIController
 def main():
     """Entry point for the FLF2V application."""
     logging.basicConfig(level=logging.INFO)
-    cfg = ConfigAgent(
-        overrides={
-            "output_path": "sample_output.mp4",
-            "frame_rate": 24,
-            "video_codec": "libx264",
-        }
-    )
+    cfg = ConfigAgent()
     gui = GUIController(cfg)
     gui.run()
 

--- a/tests/test_config_agent.py
+++ b/tests/test_config_agent.py
@@ -1,7 +1,10 @@
 import json
 import os
+import sys
 import tempfile
 import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from config_agent import ConfigAgent
 
@@ -9,7 +12,7 @@ from config_agent import ConfigAgent
 class TestConfigAgent(unittest.TestCase):
     def test_defaults(self):
         cfg = ConfigAgent()
-        self.assertEqual(cfg.get_output_path(), "output.mp4")
+        self.assertEqual(cfg.get_output_path(), "sample_output.mp4")
         self.assertEqual(cfg.get_frame_rate(), 24)
         self.assertEqual(cfg.get_video_codec(), "libx264")
 

--- a/tests/test_frame_loader.py
+++ b/tests/test_frame_loader.py
@@ -1,9 +1,12 @@
 import os
+import sys
 import tempfile
 import unittest
 
 import cv2
 import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from frame_loader import FrameLoader
 

--- a/tests/test_video_stitcher.py
+++ b/tests/test_video_stitcher.py
@@ -1,8 +1,11 @@
 import os
+import sys
 import tempfile
 import unittest
 
 import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from video_stitcher import VideoStitcher
 


### PR DESCRIPTION
## Summary
- limit GUI file picker to PNG files
- note PNG requirement in README
- drop unused CLI section from docs
- add configuration section for GUI defaults
- default output path is sample_output.mp4 by default

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6869747d6bb483268946c1238af87e9e