### PR TITLE
Add installation troubleshooting section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ error.log
 
 # Wan2.1 model
 Wan2.1/
+
+# Ignore local PyTorch wheels so they aren't committed
+deps/torch*.whl
+deps/torchaudio*.whl
+deps/torchvision*.whl

--- a/README.md
+++ b/README.md
@@ -74,3 +74,56 @@ Interpolate frames with the Wan 2.1 FLF2V model.
 
 VideoStitcher
 Stitch interpolated frames into a video using MoviePy.
+## Installation Troubleshooting
+
+Below is a running list of issues we've encountered when building or running PyTorch and CUDA-enabled extensions on Windows using PowerShell. Add new items as needed.
+
+1. **CUDA version mismatch**  
+   **Symptom:**
+   ```
+   RuntimeError: The detected CUDA version (12.9) mismatches the version that was used to compile PyTorch (11.8).
+   ```
+   **Fix:** Ensure the PyTorch wheel matches your installed CUDA Toolkit or rebuild PyTorch against the desired CUDA version.
+
+2. **Missing Python YAML module**  
+   **Symptom:**
+   ```
+   ModuleNotFoundError: No module named 'yaml'
+   ```
+   **Fix:**
+   ```powershell
+   pip install pyyaml
+   ```
+
+3. **Ninja build-backend not found**  
+   **Symptom:**
+   ```
+   UserWarning: Attempted to use ninja as the BuildExtension backend but we could not find ninja.
+   ```
+   **Fix:**
+   ```powershell
+   pip install ninja
+   ```
+
+4. **CMake not available in venv**  
+   **Symptom:**
+   ```
+   FileNotFoundError: [WinError 2] The system cannot find the file specified
+   ```
+   when CMake tries to invoke `ninja`.
+   **Fix:**
+   ```powershell
+   pip install cmake
+   ```
+
+5. **Stale CMake cache or corrupted build folder**  
+   **Symptom:** CMake repeatedly sees an old `CMakeCache.txt` referencing a missing `ninja.exe`.
+   **Fix:**
+   ```powershell
+   Remove-Item -Recurse -Force .\build
+   ```
+   Then rebuild:
+   ```powershell
+   pip install -e . --no-build-isolation
+   ```
+


### PR DESCRIPTION
## Summary
- add a new "Installation Troubleshooting" section in the README with fixes for common setup problems
- ignore local PyTorch wheels so they're not committed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for cv2 and numpy)*

------
https://chatgpt.com/codex/tasks/task_b_68697525052883269528ed3ce45b0000