### PR TITLE
Install flash-attn via Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ COPY requirements.txt /workspace/requirements.txt
 RUN pip install --upgrade pip \
  && pip install --extra-index-url https://download.pytorch.org/whl/cu118 \
       torch==2.7.1+cu118 torchvision==0.15.2+cu118 torchaudio==2.7.2+cu118 \
- && pip install -r requirements.txt
+ && pip install -r requirements.txt \
+ && pip install flash-attn --no-build-isolation
 
 # 4) Clone & install Wan2.1
 RUN git clone https://github.com/Wan-Video/Wan2.1.git


### PR DESCRIPTION
## Summary
- install `flash-attn` in the Dockerfile right after installing PyTorch

## Testing
- `docker build -t testimage .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686a8162a9948326a078f8bfc5df1b5b